### PR TITLE
Quick & Dirty update to support upstream changes.

### DIFF
--- a/shortuuid.go
+++ b/shortuuid.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	uuid "github.com/satori/go.uuid"
+	"fmt"
 )
 
 // DefaultEncoder is the default encoder uses when generating new UUIDs, and is
@@ -18,21 +19,33 @@ type Encoder interface {
 
 // New returns a new UUIDv4, encoded with base57.
 func New() string {
-	return DefaultEncoder.Encode(uuid.NewV4())
+	str, err := uuid.NewV4()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create UUIDv4: %s", err))
+	}
+	return DefaultEncoder.Encode(str)
 }
 
 // NewWithEncoder returns a new UUIDv4, encoded with enc.
 func NewWithEncoder(enc Encoder) string {
-	return enc.Encode(uuid.NewV4())
+	str, err := uuid.NewV4()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create UUIDv4: %s", err))
+	}
+	return enc.Encode(str)
 }
 
 // NewWithNamespace returns a new UUIDv5 (or v4 if name is empty), encoded with base57.
 func NewWithNamespace(name string) string {
 	var u uuid.UUID
+	var err error
 
 	switch {
 	case name == "":
-		u = uuid.NewV4()
+		u, err = uuid.NewV4()
+		if err != nil {
+			panic(fmt.Sprintf("Unable to create UUIDv4: %s", err))
+		}
 	case strings.HasPrefix(name, "http"):
 		u = uuid.NewV5(uuid.NamespaceURL, name)
 	default:
@@ -46,5 +59,9 @@ func NewWithNamespace(name string) string {
 // alternative alphabet abc.
 func NewWithAlphabet(abc string) string {
 	enc := base57{newAlphabet(abc)}
-	return enc.Encode(uuid.NewV4())
+	str, err := uuid.NewV4()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create UUIDv4: %s", err))
+	}
+	return enc.Encode(str)
 }

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -1,10 +1,10 @@
 package shortuuid
 
 import (
+	"fmt"
 	"strings"
 
 	uuid "github.com/satori/go.uuid"
-	"fmt"
 )
 
 // DefaultEncoder is the default encoder uses when generating new UUIDs, and is

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -229,7 +229,11 @@ func BenchmarkUUID(b *testing.B) {
 }
 
 func BenchmarkEncoding(b *testing.B) {
-	u := uuid.NewV4()
+	u, err := uuid.NewV4()
+	if err != nil {
+		b.Logf("Unable to create UUIDv4: %s", err)
+		b.FailNow()
+	}
 	for i := 0; i < b.N; i++ {
 		DefaultEncoder.Encode(u)
 	}


### PR DESCRIPTION
The upstream UUID package has changed the definition of `NewV4` and as a result this package has broken.

I am not in love with this proposal, but it at least takes care of the immediate problem.  I think ideally the methods should be updated to reflect the new multi-value returns seen upstream, but I did not want to destabilize head without discussion.