### PR TITLE
Use github.com/google/uuid instead of github.com/satori/go.uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,6 @@ go:
   - 1.8
   - 1.9
 
-env:
-  - DEP_VERSION="0.3.2" GO15VENDOREXPERIMENT=1
-
-before_install:
-  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
-  - chmod +x $GOPATH/bin/dep
-
-install:
-  - dep ensure
-
 script:
   go test -v
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,0 @@
-[[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2"

--- a/base57.go
+++ b/base57.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 type base57 struct {
@@ -23,7 +23,7 @@ func (b base57) Encode(u uuid.UUID) string {
 
 	// Calculate encoded length.
 	factor := math.Log(float64(25)) / math.Log(float64(b.alphabet.Length()))
-	length := math.Ceil(factor * float64(len(u.Bytes())))
+	length := math.Ceil(factor * float64(len(u)))
 
 	return b.numToString(&num, int(length))
 }
@@ -35,7 +35,7 @@ func (b base57) Decode(u string) (uuid.UUID, error) {
 	if err != nil {
 		return uuid.Nil, err
 	}
-	return uuid.FromString(str)
+	return uuid.Parse(str)
 }
 
 // numToString converts a number a string using the given alpabet.

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -3,7 +3,7 @@ package shortuuid
 import (
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // DefaultEncoder is the default encoder uses when generating new UUIDs, and is
@@ -18,12 +18,12 @@ type Encoder interface {
 
 // New returns a new UUIDv4, encoded with base57.
 func New() string {
-	return DefaultEncoder.Encode(uuid.NewV4())
+	return DefaultEncoder.Encode(uuid.New())
 }
 
 // NewWithEncoder returns a new UUIDv4, encoded with enc.
 func NewWithEncoder(enc Encoder) string {
-	return enc.Encode(uuid.NewV4())
+	return enc.Encode(uuid.New())
 }
 
 // NewWithNamespace returns a new UUIDv5 (or v4 if name is empty), encoded with base57.
@@ -32,11 +32,11 @@ func NewWithNamespace(name string) string {
 
 	switch {
 	case name == "":
-		u = uuid.NewV4()
+		u = uuid.New()
 	case strings.HasPrefix(name, "http"):
-		u = uuid.NewV5(uuid.NamespaceURL, name)
+		u = uuid.NewSHA1(uuid.NameSpaceURL, []byte(name))
 	default:
-		u = uuid.NewV5(uuid.NamespaceDNS, name)
+		u = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(name))
 	}
 
 	return DefaultEncoder.Encode(u)
@@ -46,5 +46,5 @@ func NewWithNamespace(name string) string {
 // alternative alphabet abc.
 func NewWithAlphabet(abc string) string {
 	enc := base57{newAlphabet(abc)}
-	return enc.Encode(uuid.NewV4())
+	return enc.Encode(uuid.New())
 }

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -3,7 +3,7 @@ package shortuuid
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 var testVector = []struct {
@@ -181,7 +181,7 @@ func TestGeneration(t *testing.T) {
 
 func TestEncoding(t *testing.T) {
 	for _, test := range testVector {
-		u, err := uuid.FromString(test.uuid)
+		u, err := uuid.Parse(test.uuid)
 		if err != nil {
 			t.Error(err)
 		}
@@ -196,7 +196,7 @@ func TestEncoding(t *testing.T) {
 
 func TestDecoding(t *testing.T) {
 	for _, test := range testVector {
-		u1, err := uuid.FromString(test.uuid)
+		u1, err := uuid.Parse(test.uuid)
 		if err != nil {
 			t.Error(err)
 		}
@@ -215,7 +215,7 @@ func TestDecoding(t *testing.T) {
 func TestNewWithAlphabet(t *testing.T) {
 	abc := DefaultAlphabet[:len(DefaultAlphabet)-1] + "="
 	enc := base57{newAlphabet(abc)}
-	u1, _ := uuid.FromString("e9ae9ba7-4fb1-4a6d-bbca-5315ed438371")
+	u1, _ := uuid.Parse("e9ae9ba7-4fb1-4a6d-bbca-5315ed438371")
 	u2 := enc.Encode(u1)
 	if u2 != "u=BFWRLr5dXbeWf==iasZi" {
 		t.Errorf("expected uuid to be %q, got %q", "u=BFWRLr5dXbeWf==iasZi", u2)
@@ -229,7 +229,7 @@ func BenchmarkUUID(b *testing.B) {
 }
 
 func BenchmarkEncoding(b *testing.B) {
-	u := uuid.NewV4()
+	u := uuid.New()
 	for i := 0; i < b.N; i++ {
 		DefaultEncoder.Encode(u)
 	}


### PR DESCRIPTION
Given the recent issues with `github.com/satori/go.uuid` (https://github.com/satori/go.uuid/issues/66), which are still partly unresolved, e.g. its master isn't compatible with us (see #7, #8, #9, 10, #11 and #12).

Even though [`github.com/google/uuid`](https://github.com/google/uuid) is only at v0.1 and clearly states this:

>This package is currently in development and the API may not be stable.
>
>The API will become stable with v1.

I suspect it's a better longterm investment. And speed wise they seem pretty identical:

**google/uuid**

```
BenchmarkUUID-4       	  200000	   7967 ns/op	    5768 B/op	   157 allocs/op
BenchmarkEncoding-4   	  200000	   6635 ns/op	    5776 B/op	   157 allocs/op
BenchmarkDecoding-4   	 1000000	   2126 ns/op	    1228 B/op	    38 allocs/op
```

**satori/go.uuid**

```
BenchmarkUUID-4       	  200000	   8188 ns/op	    5768 B/op	   157 allocs/op
BenchmarkEncoding-4   	  200000	   6726 ns/op	    5776 B/op	   157 allocs/op
BenchmarkDecoding-4   	 1000000	   2156 ns/op	    1228 B/op	    38 allocs/op
```